### PR TITLE
Add grunt-cli as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "uglify-js": "1.2.x",
         "jshint": ">0.0.0",
         "grunt": "~0.4.0",
+        "grunt-cli": "~0.1.0",
         "grunt-contrib-jshint": ">0.0.0",
         "grunt-contrib-nodeunit": ">0.0.0",
         "grunt-contrib-uglify": ">0.0.0"


### PR DESCRIPTION
I ran into an error attempting to run tests with `grunt test` because I didn't have grunt-cli installed globally.

Might be useful to have it as a dev dependency so grunt newbies don't get hung up.
