### PR TITLE
Set main to source usertiming.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Nic Jansma <nic@nicj.net>"
   ],
   "description": "W3C UserTiming polyfill",
-  "main": "dist/usertiming.min.js",
+  "main": "src/usertiming.js",
   "keywords": [
     "usertiming",
     "polyfill",


### PR DESCRIPTION
The `main` property should not be a minified file as recommended by the bower specification.

https://github.com/bower/bower.json-spec#main

/cc @nicjansma @eanakashima
