### PR TITLE
Inconsistent bower package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "usertiming.js",
+  "name": "usertiming",
   "version": "0.1.0",
   "homepage": "https://github.com/nicjansma/usertiming.js",
   "authors": [


### PR DESCRIPTION
Is there a reason the package is registered on bower as `usertiming.js` and not `usertiming` like the npm package? 

The extensionless style is preferred.

I have admin access to the bower package registry and can help rename the package there if you'd like?

/cc @nicjansma @eanakashima
