### PR TITLE
Remove "src" from bower ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
     "deps",
     "node_modules",
     "bower_components",
-    "src",
     "test",
     "test-w3c",
     "tests"


### PR DESCRIPTION
Just noticed one last thing: since #3, we'll need `bower install` to import /src as well.
