### PR TITLE
Fix polyfill methods being removed in Safari 8

### DIFF
--- a/src/usertiming.js
+++ b/src/usertiming.js
@@ -23,6 +23,11 @@
         window.performance = {};
     }
 
+    // We need to keep a global reference to the window.performance object to
+    // prevent any added properties from being garbage-collected in Safari 8.
+    // https://bugs.webkit.org/show_bug.cgi?id=137407
+    window._perfRefForUserTimingPolyfill = window.performance;
+
     //
     // Note what we shimmed
     //


### PR DESCRIPTION
We ran into an interesting issue with usertiming.js in the new Safari 8:

Since there's Navigation Timing support but no Performance Timeline support, the `window.performance` object is provided by the browser, but we still need to modify it to add methods like `performance.mark` and `performance.measure`. Safari 8 doesn't support adding properties to the built-in performance object in a stable way though. Triggering certain events or opening/closing the dev tools causes the object to be reset, so all of the properties we've added with the polyfill disappear. (See this [JS Fiddle](http://jsfiddle.net/dss8wudw/3/) in Safari 8 to test it out.)

Not sure if the solution here is necessarily the best way to solve this, just wanted to toss it out there and see what you think.

~~This PR creates a new proxy object that we attach all the shims to. If we needed to shim anything, we set `window.performance` to the new object, copying over references to any built-in performance methods/properties onto the new object so those are also available. It's been tested in IE 9-11, Safari 7-8, latest Firefox & Chrome — if you're interested in going this route I can also try to get my hands on VMs of the earlier IE versions and test there too.~~
