### PR TITLE
Check that window.define is a function

### DIFF
--- a/src/usertiming.js
+++ b/src/usertiming.js
@@ -546,7 +546,7 @@
     // When included directly via a script tag in the browser, we're good as we've been
     // updating the window.performance object.
     //
-    if (typeof define !== "undefined" && define.amd) {
+    if (typeof define === "function" && define.amd) {
         //
         // AMD / RequireJS
         //


### PR DESCRIPTION
This is the typical pattern since `define` is called if the condition evaluates to true.