### PR TITLE
add support for node process.hrtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "expect.js": "^0.3.1",
-        "grunt": ">= 0.4.0",
+        "grunt": "^0.4.0",
         "grunt-contrib-clean": "^0.6.0",
         "grunt-contrib-uglify": ">0.0.0",
         "grunt-karma": "^0.10.1",

--- a/src/usertiming.js
+++ b/src/usertiming.js
@@ -75,6 +75,12 @@
         var nowOffset = +(new Date());
         if (window.performance.timing && window.performance.timing.navigationStart) {
             nowOffset = window.performance.timing.navigationStart;
+        } else if (typeof process !== "undefined" && typeof process.hrtime === "function") {
+            nowOffset = process.hrtime();
+            window.performance.now = function() {
+                var time = process.hrtime(nowOffset);
+                return time[0] * 1e3 + time[1] * 1e-6;
+            }
         }
 
         if (typeof window.performance.now !== "function") {


### PR DESCRIPTION
This is just a simple modification to add support for node's process.hrtime() when available. Which will allow for higher precision in a node environment similar to the native performance.now in browsers.

I had to change the grunt version value to "^0.4.0" because ">=0.4.0" was giving me 0.6.0 and it was throwing peer dependency errors.